### PR TITLE
feat(landing): add landing page templates with base layout and homepa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,10 +56,6 @@ Pipfile.lock
 **/migrations/*.pyc
 !*/migrations/__init__.py
 
-# Compiled HTML/PDF files
-*.pdf
-*.html
-
 # System files
 .DS_Store
 Thumbs.db

--- a/landing/templates/landing/base.html
+++ b/landing/templates/landing/base.html
@@ -1,0 +1,56 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>INSERF Portal</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Bootstrap 5 -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+
+  <!-- AOS CSS -->
+  <link href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" rel="stylesheet">
+
+  <link rel="stylesheet" href="{% static 'css/style.css' %}">
+</head>
+<body class="d-flex flex-column min-vh-100 bg-light">
+
+  <!-- Header -->
+  <header class="bg-white shadow-sm fixed-top">
+    <div class="container d-flex justify-content-between align-items-center py-2">
+      <a href="/" class="d-flex align-items-center text-decoration-none">
+        <img src="{% static 'images/logo.png' %}" alt="Logo INSERF" height="40" class="logo-header me-2">
+        <span class="fs-5 fw-semibold text-dark">INSERF</span>
+      </a>
+    </div>
+  </header>
+
+  <!-- Main content -->
+  <main class="flex-grow-1">
+    {% block content %}{% endblock %}
+  </main>
+
+  <!-- Footer -->
+  <footer class="bg-dark text-white text-center py-4 mt-auto">
+    <div class="container">
+      <img src="{% static 'images/logo.png' %}" alt="Logo Footer" height="30" class="logo-footer mb-2">
+      <p class="mb-0">INSERF LTDA. © 2025 - Importadora de artículos de pesca</p>
+    </div>
+  </footer>
+
+  <!-- Bootstrap JS -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+  <!-- AOS JS -->
+  <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
+  <script>
+    AOS.init({
+      once: true,
+      duration: 800,
+      offset: 120
+    });
+  </script>
+
+</body>
+</html>

--- a/landing/templates/landing/home.html
+++ b/landing/templates/landing/home.html
@@ -1,0 +1,95 @@
+{% extends 'landing/base.html' %}
+{% load static %}
+
+{% block content %}
+
+<!-- Hero principal -->
+<section class="hero-banner d-flex align-items-center text-center text-white"
+         style="background: linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)), url('{% static 'images/hero-bg.png' %}') center center / cover no-repeat; height: 80vh;"
+         data-aos="fade-in">
+  <div class="container" data-aos="zoom-in" data-aos-delay="200">
+    <h1 class="display-5 fw-bold">Bienvenido al portal mayorista de INSERF</h1>
+    <p class="lead">Distribuidores oficiales de <strong>Jackall Japón</strong> en Chile.</p>
+    <a href="#" class="btn btn-primary btn-lg mt-3">Ingresar al catálogo</a>
+  </div>
+</section>
+
+<!-- Carrusel de productos destacados -->
+<section class="py-5 bg-white" data-aos="fade-up">
+  <div class="container">
+    <div id="landingCarousel" class="carousel slide shadow-sm rounded overflow-hidden" data-bs-ride="carousel">
+      <div class="carousel-inner">
+        <div class="carousel-item active">
+          <img src="{% static 'images/banner1.png' %}" class="d-block w-100" alt="Producto 1">
+        </div>
+        <div class="carousel-item">
+          <img src="{% static 'images/banner2.png' %}" class="d-block w-100" alt="Producto 2">
+        </div>
+        <div class="carousel-item">
+          <img src="{% static 'images/banner3.png' %}" class="d-block w-100" alt="Producto 3">
+        </div>
+      </div>
+      <button class="carousel-control-prev" type="button" data-bs-target="#landingCarousel" data-bs-slide="prev">
+        <span class="carousel-control-prev-icon"></span>
+      </button>
+      <button class="carousel-control-next" type="button" data-bs-target="#landingCarousel" data-bs-slide="next">
+        <span class="carousel-control-next-icon"></span>
+      </button>
+    </div>
+  </div>
+</section>
+
+<!-- Sección quiénes somos -->
+<section class="py-5 bg-light" data-aos="fade-up" data-aos-delay="100">
+  <div class="container text-center">
+    <h2 class="fw-bold mb-4">¿Quiénes somos?</h2>
+    <p class="lead text-muted">
+      INSERF LTDA. es una microempresa familiar chilena dedicada a la importación y distribución mayorista de artículos de pesca deportiva.
+      Con una alianza exclusiva con Jackall Japón, ofrecemos productos de alta calidad a negocios especializados en todo el país.
+    </p>
+  </div>
+</section>
+
+<!-- Beneficios de comprar con nosotros -->
+<section class="py-5 bg-white">
+  <div class="container">
+    <h2 class="fw-bold text-center mb-5" data-aos="fade-up">¿Por qué elegirnos?</h2>
+    <div class="row text-center g-4">
+      <div class="col-md-4" data-aos="fade-up" data-aos-delay="100">
+        <div class="card border-0 shadow-sm h-100">
+          <div class="card-body">
+            <h5 class="card-title fw-semibold">Representación oficial</h5>
+            <p class="card-text text-muted">Distribuidores autorizados de Jackall, Cian y Sabull en Chile.</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4" data-aos="fade-up" data-aos-delay="200">
+        <div class="card border-0 shadow-sm h-100">
+          <div class="card-body">
+            <h5 class="card-title fw-semibold">Atención personalizada</h5>
+            <p class="card-text text-muted">Nos adaptamos a cada cliente mayorista con condiciones preferenciales.</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4" data-aos="fade-up" data-aos-delay="300">
+        <div class="card border-0 shadow-sm h-100">
+          <div class="card-body">
+            <h5 class="card-title fw-semibold">Catálogo en línea</h5>
+            <p class="card-text text-muted">Visualiza productos, stock y haz pedidos fácilmente desde cualquier dispositivo.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Contacto -->
+<section class="py-5 bg-light" data-aos="zoom-in">
+  <div class="container text-center">
+    <h2 class="fw-bold mb-4">¿Necesitas más información?</h2>
+    <p class="text-muted">Escríbenos a <a href="mailto:contacto@inserf.cl">contacto@inserf.cl</a> o contáctanos vía WhatsApp para atención directa a distribuidores.</p>
+    <a href="mailto:contacto@inserf.cl" class="btn btn-outline-primary">Contáctanos</a>
+  </div>
+</section>
+
+{% endblock %}


### PR DESCRIPTION
…ge content

- Created `base.html` template with reusable layout including Bootstrap 5 and AOS animation library.
- Built `home.html` with hero section, product carousel, company overview, benefits, and contact section.
- Added reference to static assets such as images and CSS styles.
- Created placeholder `login.html` file under `landing/templates/landing/`.
- Cleaned up `.gitignore` by removing unnecessary rules for PDF and HTML files.